### PR TITLE
🧹 [code health improvement] Use IndicatorTypes instead of hardcoded strings

### DIFF
--- a/report_to_otx/report_to_otx.py
+++ b/report_to_otx/report_to_otx.py
@@ -102,7 +102,7 @@ def create_pulse(otx: OTXv2, cfg: dict, ips: list):
     """
     p = cfg["pulse"]
 
-    indicators = [{"indicator": ip, "type": "IPv4"} for ip in ips]
+    indicators = [{"indicator": ip, "type": IndicatorTypes.IPv4} for ip in ips]
 
     # Create the pulse itself
     try:
@@ -131,7 +131,7 @@ def sync_pulse_indicators(otx: OTXv2, pulse_id: str, ips: list):
     for ip, dt in ips:
         if ip not in existing_indicators:
             indicator = {
-                "type":      "IPv4",
+                "type":      IndicatorTypes.IPv4,
                 "indicator": ip
             }
             try:


### PR DESCRIPTION
This change addresses the unused import of `IndicatorTypes` in `report_to_otx/report_to_otx.py` not by removing it, but by implementing its proper usage as requested.

**Changes:**
- Replaced hardcoded `"IPv4"` strings with `IndicatorTypes.IPv4` in the `create_pulse` and `sync_pulse_indicators` functions.
- This ensures the `IndicatorTypes` import is utilized and follows best practices for the AlienVault OTXv2 Python SDK.

**Verification:**
- Ran `ruff check report_to_otx/report_to_otx.py` and confirmed no errors or unused import warnings.
- Ran `python3 -m py_compile report_to_otx/report_to_otx.py` to ensure the script is syntactically correct.
- Removed `__pycache__` to keep the repository clean.

---
*PR created automatically by Jules for task [15210696154232165460](https://jules.google.com/task/15210696154232165460) started by @PeterGabaldon*