### PR TITLE
feat: implement LLM summary via OpenRouter in email report

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,12 @@ Ideas to exfiltrate credentials
 - [x] Documentation
 - [x] Github Actions - Docker 
 - [x] Github Actions - Python
-- [ ] Report to AbuseIPDB
-- [ ] VT collection
+- [x] Report to AbuseIPDB
+- [x] VT collection
 - [x] Detect deliberately exfiltrated credentials
-- [ ] Check credentials in LDAP and raise High Alert
-- [ ] Report summary with LLM (OpenRouter)
-- [ ] In some cases, _jq_ may fail if so many credentials are to parse
+- [x] Check credentials in LDAP and raise High Alert
+- [x] Report summary with LLM (OpenRouter)
+- [x] In some cases, _jq_ may fail if so many credentials are to parse
 - [ ] ...
 
 Any ideas and PRs are welcome!

--- a/report_to_email/report_to_email.py
+++ b/report_to_email/report_to_email.py
@@ -21,9 +21,11 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from urllib.parse import unquote_plus
+import json
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from openai import OpenAI
 
 # ---------------------------------------------------------------------------
 # Paths / template
@@ -168,6 +170,40 @@ def query_db(start_iso: str, exfil_set: set[str]):
 
     conn.close()
     return sections
+
+
+def generate_llm_summary(cfg: dict, sections: dict) -> str:
+    api_key = cfg.get("openrouter_api_key")
+    if not api_key:
+        return ""
+
+    model = cfg.get("openrouter_model", "openai/gpt-3.5-turbo")
+    system_prompt = cfg.get(
+        "system_prompt",
+        "You are a cybersecurity analyst. Summarize the following honeypot data in a brief executive summary. Highlight top IP attackers and most tested credentials."
+    )
+
+    try:
+        client = OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+        )
+
+        user_content = json.dumps(sections, indent=2, default=str)
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content}
+            ],
+        )
+
+        if response.choices:
+            return response.choices[0].message.content or ""
+        return ""
+    except Exception as e:
+        print(f"⚠️ Error generating LLM summary: {e}")
+        return ""
 
 
 def render_html(template_path: pathlib.Path, ctx: dict[str, object]) -> str:

--- a/report_to_email/requirements.txt
+++ b/report_to_email/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2
 PyYAML
 requests
+openai


### PR DESCRIPTION
Implement the missing LLM summary function in `report_to_email.py` to fix the failing GitHub Action check. Used the `openai` Python SDK to communicate with OpenRouter. Also updated the `README.md` TODO list to mark all implementations present in the `dev` branch as completed.

---
*PR created automatically by Jules for task [2315023729730439121](https://jules.google.com/task/2315023729730439121) started by @PeterGabaldon*