### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in Jinja2 Template rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-07 - Jinja2 Template Autoescape Configuration
+**Vulnerability:** XSS vulnerability in template rendering due to missing autoescape configuration for `.jinja` file extensions in `select_autoescape`.
+**Learning:** `select_autoescape(["html", "xml"])` does not cover files ending with `.html.jinja`. Variables injected into these files were entirely unescaped, allowing for cross-site scripting attacks or HTML injection in email reports and alerts.
+**Prevention:** Always ensure all template file extensions used in the project are explicitly added to the `select_autoescape` list, particularly when dealing with custom or chained extensions like `.html.jinja`.

--- a/check_in_ldap/check_ldap.py
+++ b/check_in_ldap/check_ldap.py
@@ -181,7 +181,7 @@ def save_last_timestamp(ts):
 def render_html_alert(user, password):
     env = Environment(
         loader=FileSystemLoader(os.path.dirname(TEMPLATE_PATH)),
-        autoescape=select_autoescape(["html", "xml"])
+        autoescape=select_autoescape(["html", "xml", "jinja"])
     )
     template = env.get_template(os.path.basename(TEMPLATE_PATH))
     return template.render(user=user, password=password)

--- a/report_to_email/report_to_email.py
+++ b/report_to_email/report_to_email.py
@@ -259,7 +259,7 @@ def generate_llm_summary(cfg: dict, sections: dict) -> str:
 
 
 def render_html(template_path: pathlib.Path, ctx: dict[str, object]) -> str:
-    env = Environment(loader=FileSystemLoader(str(template_path.parent)), autoescape=select_autoescape(["html", "xml"]))
+    env = Environment(loader=FileSystemLoader(str(template_path.parent)), autoescape=select_autoescape(["html", "xml", "jinja"]))
     return env.get_template(template_path.name).render(**ctx)
 
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Jinja2 `select_autoescape` was missing the `.jinja` extension. Templates with the `.html.jinja` extension were not being automatically escaped, leaving them vulnerable to Cross-Site Scripting (XSS) and HTML injection when rendering unverified honeypot data (usernames, passwords, etc.).
🎯 **Impact:** An attacker could inject malicious HTML or Javascript into the LDAP compromise alert emails or daily email reports by logging in with crafted credentials.
🔧 **Fix:** Added `"jinja"` to the `select_autoescape` list in `check_in_ldap/check_ldap.py` and `report_to_email/report_to_email.py` so that `.html.jinja` templates are correctly escaped.
✅ **Verification:** Verified with `flake8` for syntax correctness and validated the AI agent logic to ensure XSS injection is mitigated during report rendering.

---
*PR created automatically by Jules for task [4905481311166805497](https://jules.google.com/task/4905481311166805497) started by @PeterGabaldon*